### PR TITLE
Reorder and clarify installation instructions

### DIFF
--- a/src/meta/metadata.yaml
+++ b/src/meta/metadata.yaml
@@ -19,10 +19,10 @@ pages:
   - intro/index.md
 
   - setup/index.md
-  - setup/background.md
-  - setup/github.md
   - setup/terminal.md
   - setup/intellij.md
+  - setup/background.md
+  - setup/github.md
  
   - expressions/index.md
   - expressions/literals.md

--- a/src/pages/intro/index.md
+++ b/src/pages/intro/index.md
@@ -96,4 +96,4 @@ or by email:
 
 Creative Scala was written by [Dave Gurnell][twitter-dave] and [Noel Welsh][twitter-noel]. Many thanks to [Richard Dallaway][twitter-richard], [Jonathan Ferguson][twitter-jono], and the team at [Underscore][underscore] for their invaluable contributions and extensive proof reading.
 
-Thanks also to the many people who pointed out errors or made suggestions to improve the book: Neil Moore; Kelley Robinson, Julie Pitt, and the other ScalaBridge organizers; d43, all the students who worked through Creative Scala at ScalaBridge, at another event, or on their own; and the many awesome members of the Scala community who gave us comments and suggestions. 
+Thanks also to the many people who pointed out errors or made suggestions to improve the book: Neil Moore; Kelley Robinson, Julie Pitt, and the other ScalaBridge organizers; d43; all the students who worked through Creative Scala at ScalaBridge, at another event, or on their own; and the many awesome members of the Scala community who gave us comments and suggestions. 

--- a/src/pages/setup/github.md
+++ b/src/pages/setup/github.md
@@ -3,14 +3,47 @@
 We have created a [template] for you that will get you setup with all the code you need to work through Creative Scala.
 This template is stored on [Github][github], a website for sharing code.
 
-If you do not have a Github account, create one now.
+You can copy the template onto your computer, which Git calls cloning, but this means you won't be able to save any changes you make back to Github where other people can view them.
 
-Once you have an account, visit the [template] (https://github.com/underscoreio/creative-scala-template) in your browser. 
+If you want to be able to share your changes you need to make a copy of the template project on Github that you own.
+Git calls this forking.
+You fork the repository on Github and then clone *your fork* to your computer.
+Then you can save your changes back to your fork on Github.
+
+To start this process you need to create a Github account, if you do not have one already.
+
+Once you have an account, visit the [template project] (https://github.com/underscoreio/creative-scala-template) in your browser. 
 At the top right is button called "Fork". 
 Press this button to create your own copy of the template.
 You will be taken to a web page displaying your own fork of the template.
-Remember the name of this repository (it should be something like `yourname/creative-scala-template` where `yourname` is your Github user name) as you will need it later.
+Remember the name of this repository (it should be something like `yourname/creative-scala-template` where `yourname` is your Github user name).
 
+Now cloning your fork is as simple as running
+
+```bash
+git clone git@github.com:yourname/creative-scala.git
+```
+
+replacing `yourname` with your actual Github user name.
+
+Now any changes you make can be sent back to your fork on Github.
+The process for doing this in Git is a bit involved.
+When you've made a change you must:
+
+  - `add` the change to what's called Git's index;
+  - `commit` the change; and finally
+  - `push` the change to the fork.
+  
+Here's an example of using the command line to do this.
+
+```bash
+git add
+git commit -m "Explain here what you did"
+git push
+```
+
+Github make a nice free graphical tool for using Git, called [Github Desktop](https://desktop.github.com/).
+It's probably the easiest way to use Git when you're getting started.
 
 [github]: https://github.com/
 [template]: https://github.com/underscoreio/creative-scala-template

--- a/src/pages/setup/index.md
+++ b/src/pages/setup/index.md
@@ -2,9 +2,9 @@
 
 Our first step is to install the software we need to work with Creative Scala. We describe two pathways here:
 
-1. Working with a text editor and a terminal. We recommend this setup to people completely new to programming as there are fewer moving parts.
+1. Working with a text editor and a terminal. *We recommend this setup to people completely new to programming* as there are fewer moving parts.
 2. Working with IntelliJ IDEA. We recommend this setup to people who are used to using an IDE or are uncomfortable with the terminal.
 
 If you're an experienced developer with a setup you are happy with just keep the tools you know and adapt the instructions below as needed.
 
-If all this stuff is new we start with a bit of background.
+If all this stuff is new to you, the rest of the chapter has some background.

--- a/src/pages/setup/terminal.md
+++ b/src/pages/setup/terminal.md
@@ -1,12 +1,12 @@
 ## Installing Terminal Software and a Text Editors
 
-This section is for you if you've decided to go the terminal and text editor route. 
+This section is our recommended setup for people new to programming, and describes how to setup Creative Scala with the terminal and a text editor. 
 We need to install:
 
 - the JVM;
 - Git;
 - a text editor; and
-- the code for Creative Scala.
+- the template project for Creative Scala.
 
 
 ### OS X
@@ -50,16 +50,20 @@ Now we will use Git to get an SBT project that will work with Creative Scala.
 Type
 
 ```bash
-git clone yourname/creative-scala-template
+git clone https://github.com/underscoreio/creative-scala-template.git
 ```
 
-replacing `yourname` with your Github username. 
-If you have not forked the repository from Github you can clone the original.
-This means you won't be (easily) able to upload your work to Github and share it with others.
+<div class="callout callout-info">
+#### Sharing Your Work {-}
 
-```bash
-git clone underscoreio/creative-scala-template
-```
+There is an alternative setup that involves first forking the Creative Scala template project, and then cloning it to your computer.
+This is the setup to choose if you want to share your work with other people; for example you might be taking Creative Scala with a remote instructor or you might just (quite rightfully) be proud of your work.
+
+In this setup you first *fork* the Creative Scala template.
+Then you make a clone of *your* fork.
+This alternative setup is described in more detail in the section on Github later in this chapter.
+</div>
+
 
 Now change to the directory we just created and run SBT.
 
@@ -80,7 +84,7 @@ and an image of three circles should appear!
 
 If you've made it this far you've successfully installed all the software you need for work through Creative Scala.
 
-The final step is to load Atom and use it to open `Example.scala`.
+The final step is to load Atom and use it to open `Example.scala`, which you can find in `src/main/scala`.
 
 
 ### Windows
@@ -103,17 +107,21 @@ Select that option.
 A window will open up with a command prompt.
 Type
 
-```bash
-git clone yourname/creative-scala-template
-```
-
-replacing `yourname` with your Github username. 
-If you have not forked the repository from Github you can clone the original.
-This means you won't be (easily) able to upload your work to Github and share it with others.
 
 ```bash
-git clone underscoreio/creative-scala-template
+git clone https://github.com/underscoreio/creative-scala-template.git
 ```
+
+<div class="callout callout-info">
+#### Sharing Your Work {-}
+
+There is an alternative setup that involves first forking the Creative Scala template project, and then cloning it to your computer.
+This is the setup to choose if you want to share your work with other people; for example you might be taking Creative Scala with a remote instructor or you might just (quite rightfully) be proud of your work.
+
+In this setup you first *fork* the Creative Scala template.
+Then you make a clone of *your* fork.
+This alternative setup is described in more detail in the section on Github later in this chapter.
+</div>
 
 Open a normal command-prompt.
 Click on the Windows icon on the bottom left of the screen.
@@ -143,7 +151,7 @@ and an image of three circles should appear!
 
 If you've made it this far you've successfully installed all the software you need for work through Creative Scala.
 
-The final step is to load Atom and use it to open `Example.scala`.
+The final step is to load Atom and use it to open `Example.scala`, which you can find in the directory `src\main\scala`.
 
 
 ### Linux


### PR DESCRIPTION
Closes #14.

Put the install instructions first, because will just skip over the rest.

Clarify the wording, and point people to cloning the template first with a clear
message about forking if they desire.

Fix Github URL.