### PR TITLE
fix typo

### DIFF
--- a/src/pages/generative/flatmap.md
+++ b/src/pages/generative/flatmap.md
@@ -266,7 +266,7 @@ val programOne =
 ```
 
 which makes it clearer that we're generating three different circles.
-
+</div>
 
 #### Colored Boxes {-}
 


### PR DESCRIPTION
Fix typo of missing end of `div`.  Closing the `div` permits the rest of the document to be rendered for an `HTML` deliverable. 