### PR TITLE
Fix formatting of Java installation instructions

### DIFF
--- a/src/pages/setup/terminal.md
+++ b/src/pages/setup/terminal.md
@@ -13,7 +13,7 @@ We need to install:
 
 Open the terminal. (Click the magnifying icon on the top righthand side of the toolbar. Type in "terminal".)
 
-Install Java
+Install Java.
 Type into the terminal
 
 ```bash


### PR DESCRIPTION
This makes it consistent with the instructions for homebrew, git, etc. Since markdown combines lines that don't have empty lines between them, the rendered formatting looks off.