### PR TITLE
Fixes Issue #85 (and another proofreading correction)

### DIFF
--- a/book/src/pages/expressions/05-exercises.md
+++ b/book/src/pages/expressions/05-exercises.md
@@ -38,8 +38,8 @@ A bit of exploration should convince you that yes, Scala does maintain the stand
 
 Below we've written a number of expressions. For each expression, try to answer the questions:
 
-1. It will compile?
-2. If it compiles, what is it's type?
+1. Will it compile?
+2. If it compiles, what is its type?
 3. If it compiles can it be evaluated, or will it fail at run-time?
 
 Then try to check your guesses using the worksheet. If you guessed wrong, try to think about what part of your understanding is incorrect. 

--- a/book/src/pages/foreword-1.md
+++ b/book/src/pages/foreword-1.md
@@ -85,8 +85,7 @@ This is an *early access* release of Creative Scala.
 There may be typos and other errors in the text and examples.
 
 If you spot any mistakes or would like to provide feedback,
-please let us know via our [Gitter chat room][underscore-gitter]
-or by email:
+please let us know via our [Discord server][creative-scala-discord] or by email:
 
  - Dave Gurnell ([dave@underscore.io](mailto:dave@underscore.io))
  - Noel Welsh ([noel@underscore.io](mailto:noel@underscore.io))

--- a/book/src/pages/links.md
+++ b/book/src/pages/links.md
@@ -2,7 +2,7 @@
 [github-creative-scala]: https://github.com/underscoreio/creative-scala
 [essential-scala]: http://underscore.io/training/courses/essential-scala
 [underscore-github]: https://github.com/underscoreio
-[underscore-gitter]: https://gitter.im/underscoreio/scala
+[creative-scala-discord]: https://discord.com/invite/rRhcFbJxVG
 [underscore]: http://underscore.io
 [twitter-dave]: http://twitter.com/davegurnell
 [twitter-jono]: http://twitter.com/jonoabroad


### PR DESCRIPTION
Changed the Gitter link to the Creative Scala Discord invite link specified on the [Creative Scala Homepage](https://www.creativescala.org/) to fix Issue #85.

Also one more proofreading correction in [Expression Exercises](https://www.creativescala.org/creative-scala/expressions/05-exercises.html). 