### PR TITLE
Nested methods fix callstyles

### DIFF
--- a/book/src/pages/fractals/nested-methods.md
+++ b/book/src/pages/fractals/nested-methods.md
@@ -115,7 +115,7 @@ val unit = {
 def cross(count: Int): Image = {
   count match {
     case 0 => unit
-    case n => unit beside (unit above cross(n-1) above unit) beside unit
+    case n => unit.beside(unit.above(cross(n-1)).above(unit)).beside(unit)
   }
 }
 
@@ -141,7 +141,7 @@ def cross(count: Int): Image = {
   def loop(count: Int): Image = {
     count match {
       case 0 => unit
-      case n => unit beside (unit above loop(n-1) above unit) beside unit
+      case n => unit.beside(unit.above(loop(n-1)).above(unit)).beside(unit)
     }
   }
 

--- a/book/src/pages/fractals/nested-methods.md
+++ b/book/src/pages/fractals/nested-methods.md
@@ -168,12 +168,12 @@ def chessboard(count: Int): Image = {
   val redSquare   = Image.square(30).fillColor(Color.red)
 
   val base =
-    (redSquare   beside blackSquare) above (blackSquare beside redSquare)
+    (redSquare.beside(blackSquare)).above(blackSquare.beside(redSquare))
   count match {
     case 0 => base
     case n =>
       val unit = cross(n-1)
-      (unit beside unit) above (unit beside unit)
+      (unit.beside(unit)).above(unit.beside(unit))
   }
 }
 ```
@@ -194,13 +194,13 @@ def chessboard(count: Int): Image = {
   val blackSquare = Image.square(30) fillColor Color.black
   val redSquare   = Image.square(30) fillColor Color.red
   val base =
-    (redSquare   beside blackSquare) above (blackSquare beside redSquare)
+    (redSquare.beside(blackSquare)).above(blackSquare.beside(redSquare))
   def loop(count: Int): Image =
     count match {
       case 0 => base
       case n =>
         val unit = loop(n-1)
-        (unit beside unit) above (unit beside unit)
+        (unit.beside(unit)).above(unit.beside(unit))
     }
 
   loop(count)


### PR DESCRIPTION
# reason for PR & what I did:

I noticed the nested methods page in fractals had a mixture of operator style and regular method style, so I unified them to the regular style we use through the book. 

I checked the book still renders via `build` in `sbt` after the changes.

# Files affected:

 book/src/pages/fractals/nested-methods.md
 
 # Instructions for reviewers:

Are you happy with these changes? I'm confident in the changes on l.118 & l.144. 
For ll.171, 176, 197 & 203, I've kept the outermost bracket - can you confirm this is still how it's done for the regular style? 
I haven't tried to run the edited code snippets in an actual program, let me know if you'd like me to do this. 
If you're happy with the changes, feel free to merge!
Thanks :)