### PR TITLE
added titles to exercises 

### DIFF
--- a/book/src/pages/flowers/fun.md
+++ b/book/src/pages/flowers/fun.md
@@ -19,7 +19,10 @@ def fold(count: Int, build: (Int, Image) => Image): Image =
 
 Let's see if that is really the case, and get a bit more practice using functions.
 
+@:exercise(Gradient Boxes Revisited)
+
 Below is an example of a row of boxes, where the color changes from each box to the next. We've already written this as a method. Now I want you to rewrite it using `fold` and a function you create.
+@:@
 
 @:doodle("gradient-boxes", "FlowersFun.gradientBoxesExample")
 
@@ -68,7 +71,10 @@ case n =>
 and turning it into a function.
 @:@
 
+@:exercise(Decreasing Dots)
+
 Here's a variation on that idea, which changes size as well as changing color. Write this using `fold` and a function of your own construction.
+@:@
 
 @:doodle("growing-circles", "FlowersFun.growingCirclesExample")
 
@@ -90,7 +96,10 @@ fold(5, growingCircles)
 ```
 @:@
 
+@:exercise(Feeling Fractal)
+
 Let's try a fractal. Below is the Sierpinski triangle. Can you write this using `fold`? If not, why not? Can you change `fold` so you can write it using `fold`?
+@:@
 
 @:doodle("sierpinski", "FlowersSierpinski.sierpinskiExample")
 


### PR DESCRIPTION
# What did I do?

On the `Fun with Functions` page, exercises didn't have titles. I find it useful to have the titles as I name the scripts I write after them and it helps me orient myself in the book when talking through my exercises. I thought others might find them useful too, and the convention in the book seems to be to have them.

I thought it might be because they're in the middle of text, rather than at the end, but then I saw that there is another page where this is the case, and it has titles for exercises, see https://www.creativescala.org/creative-scala/programs/names.html.

tl;dr: I've added titles for each of the 3 exercises

# Files affected

book/src/pages/flowers/fun.md

# Instructions for reviewers

- Check you're happy with the changes. My titles try to emulate the witty style of the original author, I'm not sure they reach the same apex. Feel free to suggest better versions!
- I tested the changes in Chrome, Safari & Mozilla but you may want to run build again and check it renders ok. 